### PR TITLE
Fix remap().

### DIFF
--- a/lab/compare_flow.m
+++ b/lab/compare_flow.m
@@ -1,0 +1,19 @@
+close all;
+clear all;
+
+opt = double(imread('output/optDataSeq2/ps5_4c_3_warped.png'))/255.;
+nopt = double(imread('output/fixDataSeq2/ps5_4c_3_warped.png'))/255.;
+
+diff = opt - nopt;
+
+l = min(min(diff));
+h = max(max(diff));
+edges = linspace(l, h, 10);
+
+figure;
+histogram(diff, edges);
+ax = gca;
+ax.YScale = 'log';
+
+figure;
+imshow(diff, []);

--- a/lab/ps5_4a.m
+++ b/lab/ps5_4a.m
@@ -20,7 +20,7 @@ for i=1:size(indices,1)
     img0 = squeeze(seq(indices(i,1),:,:));
     img1 = squeeze(seq(indices(i,2),:,:));
 
-    [u, v, idx] = hlk(img0, img1, 6, 2, 0.01);
+    [u, v, idx] = hlk(img0, img1, 6, 3, 0.01);
     f = display_flow_uv(u, v, jet, [-45, 45]);
     save_figure(f, base_name + "_" + string(indices(i,2)) + "_uv.png");
 

--- a/lab/ps5_4b.m
+++ b/lab/ps5_4b.m
@@ -20,7 +20,7 @@ for i=1:size(indices,1)
     img0 = squeeze(seq(indices(i,1),:,:));
     img1 = squeeze(seq(indices(i,2),:,:));
 
-    [u, v, idx] = hlk(img0, img1, 5, 4, 0.02);
+    [u, v, idx] = hlk(img0, img1, 5, 5, 0.02);
     f = display_flow_uv(u, v, jet, [-10, 10]);
     save_figure(f, base_name + "_" + string(indices(i,2)) + "_uv.png");
 

--- a/src/remap.m
+++ b/src/remap.m
@@ -4,11 +4,11 @@ function dst = remap(src, u, v)
     % all imgase must have equal sizes
 
     % r0.a0
-    r0 = round(v);
+    r0 = floor(v);
     a0 = v - r0;
     
     % c0.b0
-    c0 = round(u);
+    c0 = floor(u);
     b0 = u - c0;
     
     a = lookup(src, r0, c0);


### PR DESCRIPTION
Fix remap() with incorrect usage of round()
instead of floor.

Adds script to compare two images warped by
a flow field and dispay their error as an
histogram.

Small improvements in ps5_4b. to use slightly
bigger aperture size.